### PR TITLE
rrdcached_dir doesn't exist anymore fallback to rrd_dir

### DIFF
--- a/weathermapper.php
+++ b/weathermapper.php
@@ -58,7 +58,7 @@ foreach ($weathermapper as $k => $v) {
     );
 
     // Concatenate link configs
-    $config .= create_link_config($links,$config['rrdcached_dir']);
+    $config .= create_link_config($links,$config['rrd_dir']);
 
     // Write to file
     $file = $output_dir."/".$k.".conf";


### PR DESCRIPTION
Since https://github.com/librenms/librenms/commit/e3772e265391d942e89be7917e742095f2488660
rrdcached_dir doesn't exist anymore, let's fallback to rrd_dir